### PR TITLE
Fix: Show tool help for all search results, not just namespaced classes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Tool help (📋 Use:) in search results now displays for all classes, not just namespaced ones
+- Tool help now shows for properties and methods with correct parameter formatting
+- Improved search result usability by providing copy-paste ready MCP tool commands
+
 ### Changed
 - **Reduced test count from 166 to 80 tests**
   - Streamlined test suite to focus on core functionality

--- a/src/unity_docs_mcp/server.py
+++ b/src/unity_docs_mcp/server.py
@@ -12,7 +12,6 @@ try:
     from .parser import UnityDocParser
 except ImportError:
     # Handle direct execution
-    import sys
     import os
 
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -209,8 +208,8 @@ class UnityDocsMCPServer:
                     if "." not in class_name:
                         error_msg += "**Troubleshooting tips:**\n"
                         error_msg += f"1. This class might exist in a namespace. Try searching for '{class_name}' to find the full name.\n"
-                        error_msg += f"2. Common Unity namespaces: AI, UI, VFX, Rendering, Audio, etc.\n"
-                        error_msg += f"3. Example: 'NavMeshAgent' is actually 'AI.NavMeshAgent'\n\n"
+                        error_msg += "2. Common Unity namespaces: AI, UI, VFX, Rendering, Audio, etc.\n"
+                        error_msg += "3. Example: 'NavMeshAgent' is actually 'AI.NavMeshAgent'\n\n"
 
                     error_msg += "**Note:** The API might exist but wasn't found in the tested versions."
 
@@ -296,7 +295,7 @@ class UnityDocsMCPServer:
             ]
 
         # Format the response
-        content = f"# Unity Documentation Search Results\n\n"
+        content = "# Unity Documentation Search Results\n\n"
         content += f"**Query:** {query}\n"
 
         # Show version info (including normalization if different)
@@ -316,7 +315,7 @@ class UnityDocsMCPServer:
             # Extract class name for get_unity_api_doc suggestion
             title = res.get("title", "")
             result_type = res.get("type", "")
-            
+
             # Show tool help for classes, properties, and methods
             if result_type in ["class", "property", "method", "function"]:
                 # For properties and methods, extract the base class name

--- a/src/unity_docs_mcp/server.py
+++ b/src/unity_docs_mcp/server.py
@@ -315,8 +315,20 @@ class UnityDocsMCPServer:
 
             # Extract class name for get_unity_api_doc suggestion
             title = res.get("title", "")
-            if res.get("type") == "class" and "." in title:
-                content += f'**📋 Use:** `get_unity_api_doc(class_name: "{title}", version: "{version}")`\n'
+            result_type = res.get("type", "")
+            
+            # Show tool help for classes, properties, and methods
+            if result_type in ["class", "property", "method", "function"]:
+                # For properties and methods, extract the base class name
+                if result_type in ["property", "method", "function"] and "." in title:
+                    # Split to get class and member names
+                    parts = title.split(".")
+                    class_name = ".".join(parts[:-1])
+                    member_name = parts[-1]
+                    content += f'**📋 Use:** `get_unity_api_doc(class_name: "{class_name}", method_name: "{member_name}", version: "{version}")`\n'
+                else:
+                    # For classes (with or without namespace)
+                    content += f'**📋 Use:** `get_unity_api_doc(class_name: "{title}", version: "{version}")`\n'
 
             if res.get("url"):
                 content += f"**URL:** {res['url']}\n"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,7 @@
 
 import unittest
 import asyncio
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import sys
 import os
@@ -105,20 +105,20 @@ class TestIntegration(unittest.TestCase):
                 "title": "GameObject",
                 "type": "class",
                 "url": "https://docs.unity3d.com/6000.0/Documentation/ScriptReference/GameObject.html",
-                "description": "Base class for all entities in Unity Scenes."
+                "description": "Base class for all entities in Unity Scenes.",
             },
             {
                 "title": "GameObject.CreatePrimitive",
                 "type": "method",
                 "url": "https://docs.unity3d.com/6000.0/Documentation/ScriptReference/GameObject.CreatePrimitive.html",
-                "description": "Creates a game object with a primitive mesh renderer and appropriate collider."
+                "description": "Creates a game object with a primitive mesh renderer and appropriate collider.",
             },
             {
                 "title": "GameObject.Find",
                 "type": "method",
                 "url": "https://docs.unity3d.com/6000.0/Documentation/ScriptReference/GameObject.Find.html",
-                "description": "Finds a GameObject by name and returns it."
-            }
+                "description": "Finds a GameObject by name and returns it.",
+            },
         ]
 
         # Test the complete workflow
@@ -146,7 +146,7 @@ class TestIntegration(unittest.TestCase):
         # Verify URLs are included
         self.assertIn(".html", content)
         self.assertIn("https://docs.unity3d.com", content)
-        
+
         # Verify tool help is shown for appropriate results (testing our fix)
         self.assertIn("**📋 Use:**", content)
         self.assertIn('get_unity_api_doc(class_name: "GameObject"', content)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -96,10 +96,30 @@ class TestIntegration(unittest.TestCase):
             content,
         )
 
-    @patch("unity_docs_mcp.scraper.UnityDocScraper._fetch_page")
-    async def test_full_search_workflow(self, mock_fetch):
+    @patch("unity_docs_mcp.search_index.UnitySearchIndex.search")
+    async def test_full_search_workflow(self, mock_search):
         """Test complete workflow for searching documentation."""
-        mock_fetch.return_value = self.sample_search_html
+        # Mock search results
+        mock_search.return_value = [
+            {
+                "title": "GameObject",
+                "type": "class",
+                "url": "https://docs.unity3d.com/6000.0/Documentation/ScriptReference/GameObject.html",
+                "description": "Base class for all entities in Unity Scenes."
+            },
+            {
+                "title": "GameObject.CreatePrimitive",
+                "type": "method",
+                "url": "https://docs.unity3d.com/6000.0/Documentation/ScriptReference/GameObject.CreatePrimitive.html",
+                "description": "Creates a game object with a primitive mesh renderer and appropriate collider."
+            },
+            {
+                "title": "GameObject.Find",
+                "type": "method",
+                "url": "https://docs.unity3d.com/6000.0/Documentation/ScriptReference/GameObject.Find.html",
+                "description": "Finds a GameObject by name and returns it."
+            }
+        ]
 
         # Test the complete workflow
         result = await self.server._search_unity_docs("GameObject", "6000.0")
@@ -126,6 +146,10 @@ class TestIntegration(unittest.TestCase):
         # Verify URLs are included
         self.assertIn(".html", content)
         self.assertIn("https://docs.unity3d.com", content)
+        
+        # Verify tool help is shown for appropriate results (testing our fix)
+        self.assertIn("**📋 Use:**", content)
+        self.assertIn('get_unity_api_doc(class_name: "GameObject"', content)
 
     def test_scraper_parser_integration(self):
         """Test integration between scraper and parser components."""


### PR DESCRIPTION
## Summary
- Fixed tool help (📋 Use:) to display for all search results, not just namespaced classes
- Extended tool help to show for properties and methods with proper parameter formatting
- Improved search result usability by providing copy-paste ready MCP tool commands

## Changes Made
1. **Extended tool help display logic** in `server.py`:
   - Now shows tool help for all classes (with or without namespace)
   - Added support for properties, methods, and functions
   - Correctly extracts class and member names for non-class results

2. **Updated integration test** to verify the fix works correctly

## Test Plan
- [x] Ran existing test suite - all tests pass
- [x] Manually tested with MCP Inspector:
  - Search for "GameObject" shows tool help for all results
  - Search for "Transform" shows tool help for class and its members
  - Tool help correctly formats class_name and method_name parameters

## Before/After Example

**Before**: Only classes with namespace (like `UnityEngine.GameObject`) showed tool help

**After**: All relevant results show tool help:
```
1. GameObject (class)
   📋 Use: get_unity_api_doc(class_name: "GameObject", version: "6000.0")

2. GameObject.CreatePrimitive (method)
   📋 Use: get_unity_api_doc(class_name: "GameObject", method_name: "CreatePrimitive", version: "6000.0")
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>